### PR TITLE
re-added openpyxl to requirements

### DIFF
--- a/health_centers/README.md
+++ b/health_centers/README.md
@@ -1,10 +1,10 @@
 ## How to update health_centers.csv
 ___
 In this folder run:
-1. `python3.7 -m venv venv`
+1. `python3.7 -m venv venv` or `virtualenv -p python3 venv`
 1. `source venv/bin/activate`
-1. `pip install -r requirements.txt`
-1. `python process.py`
+1. `pip install -r ../requirements.txt`
+1. `python process.py` or `python process.py --cached` if you want to work with already downloaded XLS files (dev mode)
 
 
 ## CSV field meaning

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ ipython==7.18.1; python_version >= '3.7'
 jedi==0.17.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 numpy==1.19.2; python_version >= '3.6'
 oauthlib==3.1.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+openpyxl==3.0.5
 pandas==1.1.2
 parso==0.7.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pexpect==4.8.0; sys_platform != 'win32' and sys_platform != 'win32'


### PR DESCRIPTION
@overlordtm I've re-added `openpyxl` back to requirements. It was removed in https://github.com/sledilnik/data/commit/2812aff861b2e268fce4f05b547cf4978e38b5f2, but it should not be since `health_centers` depend on it.