### PR TITLE
Rename datum to date and fix filename regex

### DIFF
--- a/lab_tests/parse_daily_tests.py
+++ b/lab_tests/parse_daily_tests.py
@@ -54,17 +54,17 @@ def parse_daily_tests(
         find_date = re.search(r"^.*(\d{4}-\d{1,2}-\d{1,2})\.xlsx$", str(xlsx))
         datums.append(find_date.group(1))
     available_files = pd.DataFrame.from_dict(
-        {"filename": [str(x) for x in find_xlsxs], "datum": datums}
+        {"filename": [str(x) for x in find_xlsxs], "date": datums}
     )
-    available_files["datum"] = pd.to_datetime(available_files["datum"]).dt.date
-    available_files = available_files.sort_values(by="datum", ascending=False)
+    available_files["date"] = pd.to_datetime(available_files["date"]).dt.date
+    available_files = available_files.sort_values(by="date", ascending=False)
     available_files = available_files.loc[0]
     xlsx = available_files["filename"]
 
     logger.info(f"Processing file {xlsx}")
 
     custom_column_names = [
-        "datum",
+        "date",
         "tests.lab.imi.performed",
         "tests.lab.imi.positive",
         "tests.lab.nlzohmb.performed",
@@ -114,7 +114,7 @@ def parse_daily_tests(
 
     # Some dates are invalid and we need to prepare them before parsing.
     for index, value in xy.iterrows():
-        interval = xy.loc[index, "datum"]
+        interval = xy.loc[index, "date"]
 
         if not isinstance(interval, datetime.datetime):
             # Catch any datum with a star at the end.
@@ -122,7 +122,7 @@ def parse_daily_tests(
 
             try:
                 end_datum = datetime.datetime.strptime(interval, "%d.%m.%Y")
-                xy.loc[index, "datum"] = end_datum
+                xy.loc[index, "date"] = end_datum
                 continue
             except ValueError:
                 pass
@@ -130,17 +130,17 @@ def parse_daily_tests(
             try:
                 end_datum = interval.split("-")[1]
                 end_datum = datetime.datetime.strptime(end_datum, "%d.%m.%Y")
-                xy.loc[index, "datum"] = end_datum
+                xy.loc[index, "date"] = end_datum
                 continue
             except IndexError:
                 pass
 
-    xy["datum"] = pd.to_datetime(xy["datum"]).dt.date
+    xy["date"] = pd.to_datetime(xy["date"]).dt.date
 
     # The table comes with dates in the future. Since some cells may be polluted,
     # the easiest thing to do is to remove them using the file datum.
-    xy = xy[xy["datum"] <= available_files["datum"]]
-    logger.warning(f"File truncated to data <= {available_files['datum']}")
+    xy = xy[xy["date"] <= available_files["date"]]
+    logger.warning(f"File truncated to data <= {available_files['date']}")
 
     # Regular tests and national study
     # tests.regular.performed
@@ -305,7 +305,7 @@ def parse_daily_tests(
 
     xy = xy[
         [
-            "datum",
+            "date",
             "tests.performed",
             "tests.performed.todate",
             "tests.positive",

--- a/lab_tests/parse_daily_tests.py
+++ b/lab_tests/parse_daily_tests.py
@@ -51,7 +51,7 @@ def parse_daily_tests(
 
     datums = []
     for xlsx in find_xlsxs:
-        find_date = re.search(r"^.*(\d{4}-\d{2}-\d{2})\.xlsx$", str(xlsx))
+        find_date = re.search(r"^.*(\d{4}-\d{1,2}-\d{1,2})\.xlsx$", str(xlsx))
         datums.append(find_date.group(1))
     available_files = pd.DataFrame.from_dict(
         {"filename": [str(x) for x in find_xlsxs], "datum": datums}

--- a/tests/test_lab_data.py
+++ b/tests/test_lab_data.py
@@ -17,7 +17,7 @@ class TestParsingTestsLab(TestCase):
             output_folder=".",
         )
         xy = pd.read_csv(self.xy_file)
-        self.assertEqual(list(xy.datum)[-1], "2020-11-20")
+        self.assertEqual(list(xy.date)[-1], "2020-11-20")
 
         self.xy_file.unlink()
         self.xy_timestamp.unlink()
@@ -30,7 +30,7 @@ class TestParsingTestsLab(TestCase):
             xlsx="test results 2020-11-19.xlsx",
         )
         xy = pd.read_csv(self.xy_file)
-        self.assertEqual(list(xy.datum)[-1], "2020-11-19")
+        self.assertEqual(list(xy.date)[-1], "2020-11-19")
 
         self.xy_file.unlink()
         self.xy_timestamp.unlink()


### PR DESCRIPTION
New regex now catches `2020-11-01` and `2020-11-1`.

Column `datum` has been renamed to `date` to make it uniform across different data sources.