### PR TITLE
Make zeros empty in lab tests results

### DIFF
--- a/lab_tests/README.md
+++ b/lab_tests/README.md
@@ -48,3 +48,18 @@ To run the script on the latest `.xlsx` file in `path`, do
 ```bash
 python parse_daily_tests.py
 ```
+
+# Testing
+To run tests, you should be located in root folder of the repository. To run all tests do
+
+```bash
+python -m unittest tests.test_lab_data
+```
+
+or 
+
+```bash
+python -m unittest tests.test_lab_data.TestParsingTestsLab.test_default_run
+```
+
+to run only specific tests.

--- a/lab_tests/parse_daily_tests.py
+++ b/lab_tests/parse_daily_tests.py
@@ -5,6 +5,7 @@ import re
 import time
 
 from clize import run
+import numpy as np
 import pandas as pd
 
 pd.set_option("display.max_columns", 30)
@@ -364,6 +365,9 @@ def parse_daily_tests(
             "tests.lab.nlzohms.positive.todate",
         ]
     ]
+
+    # For aesthetic reasons, replace zeros with NaNs.
+    xy.replace(to_replace=0, value=np.nan, inplace=True)
 
     output_file = OUTPUT / "lab-tests.csv"
     xy.to_csv(path_or_buf=output_file, sep=",", index=False)

--- a/tests/test_lab_data.py
+++ b/tests/test_lab_data.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
 import pandas as pd
 from lab_tests.parse_daily_tests import parse_daily_tests
 
@@ -18,6 +19,12 @@ class TestParsingTestsLab(TestCase):
         )
         xy = pd.read_csv(self.xy_file)
         self.assertEqual(list(xy.date)[-1], "2020-11-20")
+
+        # Make sure zeros are replaced with NaN. test.positive column should have
+        # NaN by default, but .todate column zeros are replaced with NaN post
+        # festum.
+        self.assertTrue(np.isnan(list(xy["tests.positive"])[0]))
+        self.assertTrue(np.isnan(list(xy["tests.positive.todate"])[0]))
 
         self.xy_file.unlink()
         self.xy_timestamp.unlink()


### PR DESCRIPTION
Zeros are now converted to NaN and they should appear as empty fields in the final .csv file.