### PR TITLE
Use float_format to write floats as integer in csv for lab_tests

### DIFF
--- a/lab_tests/parse_daily_tests.py
+++ b/lab_tests/parse_daily_tests.py
@@ -370,7 +370,7 @@ def parse_daily_tests(
     xy.replace(to_replace=0, value=np.nan, inplace=True)
 
     output_file = OUTPUT / "lab-tests.csv"
-    xy.to_csv(path_or_buf=output_file, sep=",", index=False)
+    xy.to_csv(path_or_buf=output_file, sep=",", index=False, float_format="%.0f")
 
     update_time = int(time.time())
 


### PR DESCRIPTION
Printing floats using this format makes them appear integer in the final output.