### PR TITLE
Fix subsetting of sorted files in parse_daily_tests.py

### DIFF
--- a/lab_tests/parse_daily_tests.py
+++ b/lab_tests/parse_daily_tests.py
@@ -59,7 +59,7 @@ def parse_daily_tests(
     )
     available_files["date"] = pd.to_datetime(available_files["date"]).dt.date
     available_files = available_files.sort_values(by="date", ascending=False)
-    available_files = available_files.loc[0]
+    available_files = available_files.iloc[0,]
     xlsx = available_files["filename"]
 
     logger.info(f"Processing file {xlsx}")


### PR DESCRIPTION
Turns out that `xy.loc[0,]` doesn't subset the first row, but row with index (name) 0. I believe using `iloc` should now sort and subset the last (by date) file correctly.