### PR TITLE
Fix index column name in stats-weekly.csv

### DIFF
--- a/transform/nijz_weekly.py
+++ b/transform/nijz_weekly.py
@@ -174,6 +174,7 @@ df_quarantine = df_quarantine[['week.sent_to.quarantine', 'week.src.quarantine']
 df_quarantine = df_quarantine.replace({0: None}).astype('Int64')
 
 merged = df_d_1.join([df_d_2, df_i_1, df_i_2, df_i_3, df_i_4, df_quarantine, df_vaccination_cases, df_icu_cases], how='outer')
+merged.index.name = 'week'
 
 week_dates = {'week': [], 'date': [], 'date.to': []}
 for x in merged.index:


### PR DESCRIPTION
The index name was accidentally removed by #148.