### PR TITLE
Fix NIJZ EPI data scraping

### DIFF
--- a/transform/nijz_daily.py
+++ b/transform/nijz_daily.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__file__)
 covid_data_path = os.getenv('COVID_DATA_PATH')
 assert covid_data_path, 'COVID_DATA_PATH env variable must be set. (The location of the COVID-DATA folder)'
 
-download_nijz_xslx_file(download_folder=os.path.join(covid_data_path, 'EPI'), search_for='dnevni_prikazi')
+download_nijz_xslx_file(download_folder=os.path.join(covid_data_path, 'EPI'), search_for='DNEVNI-PRIKAZI')
 
 SOURCE_FILE = max(glob.glob(os.path.join(covid_data_path, 'EPI') + '/dnevni_prikazi*.xlsx'))  # take latest
 logger.info(f'SOURCE_FILE: {SOURCE_FILE}')

--- a/transform/nijz_weekly.py
+++ b/transform/nijz_weekly.py
@@ -16,8 +16,8 @@ logger = logging.getLogger(__file__)
 covid_data_path = os.getenv('COVID_DATA_PATH')
 assert covid_data_path, 'COVID_DATA_PATH env variable must be set. (The location of the COVID-DATA folder)'
 
-download_nijz_xslx_file(download_folder=os.path.join(covid_data_path, 'EPI'), search_for='tedenski_prikaz_okuzeni')
-download_nijz_xslx_file(download_folder=os.path.join(covid_data_path, 'EPI'), search_for='tedenski_prikaz_umrli')
+download_nijz_xslx_file(download_folder=os.path.join(covid_data_path, 'EPI'), search_for='TEDENSKI-PRIKAZ-OKUZENI')
+download_nijz_xslx_file(download_folder=os.path.join(covid_data_path, 'EPI'), search_for='TEDENSKI-PRIKAZ-UMRLI')
 
 SOURCE_FILE_INFECTED = max(glob.glob(os.path.join(covid_data_path, 'EPI') + '/tedenski_prikaz_okuzeni*.xlsx'))  # take latest
 logger.info(f'SOURCE_FILE okuzeni: {SOURCE_FILE_INFECTED}')

--- a/transform/utils.py
+++ b/transform/utils.py
@@ -30,17 +30,17 @@ def download_nijz_xslx_file(download_folder: str, search_for: str):
 
     def get_nijz_xlsx_url(search_for: str):
         pq = pyquery.PyQuery(requests.get(
-            url='https://www.nijz.si/sl/dnevno-spremljanje-okuzb-s-sars-cov-2-covid-19',
+            url='https://nijz.si/nalezljive-bolezni/koronavirus/dnevno-spremljanje-okuzb-s-sars-cov-2-covid-19/',
             headers={'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:84.0) Gecko/20100101 Firefox/84.0'}
         ).text)
         for x in pq('a').items():
             href = x.attr['href']
             if href and search_for in href:
-                return 'https://www.nijz.si' + href
+                return href
 
     url = get_nijz_xlsx_url(search_for=search_for)
     filename = url.split('/')[-1]
-    path_file = os.path.join(download_folder, filename)
+    path_file = os.path.join(download_folder, filename.replace('-', '_').lower())
 
     if filename in os.listdir(download_folder):
         _, temp = tempfile.mkstemp()


### PR DESCRIPTION
NIJZ changed webpage location and file naming convention. This commit fixes the scraping of the data.
It searched data on new location by new names and then renames data back to old convention