### PR TITLE
Bump python from 3.8 to 3.11

### DIFF
--- a/.github/workflows/gsheets.yml
+++ b/.github/workflows/gsheets.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.11'
 
     - name: Cache pip
       uses: actions/cache@v3.3.1

--- a/.github/workflows/labtests.yml
+++ b/.github/workflows/labtests.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.11'
 
     - name: Cache pip
       uses: actions/cache@v3.3.1

--- a/.github/workflows/ostanizdrav.yml
+++ b/.github/workflows/ostanizdrav.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.11'
 
     - name: Cache pip
       uses: actions/cache@v3.3.1

--- a/.github/workflows/schools.yml
+++ b/.github/workflows/schools.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.11'
 
     - name: Cache pip
       uses: actions/cache@v3.3.1

--- a/.github/workflows/sewage.yml
+++ b/.github/workflows/sewage.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.11'
 
     - name: Cache pip
       uses: actions/cache@v3.3.1

--- a/.github/workflows/vaccination.yml
+++ b/.github/workflows/vaccination.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.11'
 
     - name: Cache pip
       uses: actions/cache@v3.3.1

--- a/.github/workflows/vaccination_opsi.yml
+++ b/.github/workflows/vaccination_opsi.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.11'
 
     - name: Cache pip
       uses: actions/cache@v3.3.1


### PR DESCRIPTION
To get bugfixes, not just security updates
https://devguide.python.org/versions/