### PR TITLE
Sewage: sort data in CSVs deterministically

### DIFF
--- a/update_sewage_opsi.py
+++ b/update_sewage_opsi.py
@@ -64,10 +64,11 @@ def update_sewage_cases(update_time):
         'sewage.region',
         'sewage.population',
         'sewage.coverage-ratio']
-    df_opsi.set_index('sewage.date', inplace=True)
     df_opsi['sewage.station'] = df_opsi['sewage.station'].apply(underscore_to_space)
     df_opsi['sewage.region'] = df_opsi['sewage.region'].apply(convert_region)
     df_opsi['sewage.coverage-ratio'] = df_opsi['sewage.coverage-ratio'].apply(fix_ratio)
+    df_opsi = df_opsi.set_index(['sewage.date', 'sewage.station'])
+    df_opsi = df_opsi.sort_values(by=['sewage.date','sewage.station'], ascending=True)
 
     print("CASES: ", df_opsi)
     
@@ -86,10 +87,11 @@ def update_sewage_genome(update_time):
         'sewage.genome',
         'sewage.ratio',
         'sewage.region']
-    df_opsi.set_index('sewage.date', inplace=True)
     df_opsi['sewage.station'] = df_opsi['sewage.station'].apply(underscore_to_space)
     df_opsi['sewage.region'] = df_opsi['sewage.region'].apply(convert_region)
     df_opsi['sewage.ratio'] = df_opsi['sewage.ratio'].apply(fix_ratio)
+    df_opsi = df_opsi.set_index(['sewage.date', 'sewage.station', 'sewage.genome'])
+    df_opsi = df_opsi.sort_values(by=['sewage.date', 'sewage.station', 'sewage.genome'], ascending=True)
 
     print("GENOME: ", df_opsi)
     


### PR DESCRIPTION
...instead of leaving them sorted as they were on OPSI

Order on OPSI is presumably:
- genomes by date of entry
- cases by sampling station type+name, then by date

This orders them by date and next one or two more columns that should be forming a unique composite PK.

This should generate nicer, shorter git diffs and make it obvious if the old data is changed.